### PR TITLE
feat(api): secure ImageKit routes with auth and rate limiting

### DIFF
--- a/lms-course-platform/src/app/api/imagekit/delete/route.ts
+++ b/lms-course-platform/src/app/api/imagekit/delete/route.ts
@@ -1,8 +1,57 @@
 import { env } from "@/lib/env";
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import arcjet, { detectBot, fixedWindow } from "@/lib/arcjet";
+import { auth } from "@/lib/auth";
+
+// Route-specific Arcjet rules
+const aj = arcjet
+    .withRule(
+        detectBot({
+            mode: "LIVE",
+            allow: [],
+        })
+    )
+    .withRule(
+        fixedWindow({
+            mode: "LIVE",
+            window: "1m",
+            max: 5,
+        })
+    );
 
 export async function DELETE(request: Request) {
     try {
+
+        // Check Authentication
+        const session = await auth.api.getSession({
+            headers: await headers(),
+        });
+
+        // Check if the user is authenticated
+        if (!session?.user) {
+            return NextResponse.json({
+                error: "Unauthorized",
+            }, {
+                status: 401
+            });
+        }
+
+        // Protect the route with Arcjet
+        const decision = await aj.protect(request, {
+            fingerprint: session.user.id,
+        });
+
+        // Check if the request is denied by Arcjet
+        if (decision.isDenied()) {
+            return NextResponse.json({
+                error: "Too many requests",
+            }, {
+                status: 429
+
+            });
+        }
+
         const body = await request.json();
 
         const { fileId } = body;
@@ -22,8 +71,7 @@ export async function DELETE(request: Request) {
             headers: {
                 Authorization: `Basic ${credentials}`,
             },
-        }
-        );
+        });
 
         if (!response.ok) {
             const error = await response.text();
@@ -44,7 +92,7 @@ export async function DELETE(request: Request) {
 
     } catch (error) {
         console.error("ImageKit delete error:", error);
-        
+
         return NextResponse.json({
             error: "Failed to delete file",
         }, {

--- a/lms-course-platform/src/app/api/imagekit/upload/route.ts
+++ b/lms-course-platform/src/app/api/imagekit/upload/route.ts
@@ -1,9 +1,59 @@
 import { getUploadAuthParams } from "@imagekit/next/server";
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 import { env } from "@/lib/env";
+import arcjet, { detectBot, fixedWindow } from "@/lib/arcjet";
+import { auth } from "@/lib/auth";
 
-export async function GET() {
+// Route-specific Arcjet rules
+const aj = arcjet
+    .withRule(
+        detectBot({
+            mode: "LIVE",
+            allow: [],
+        })
+    )
+    .withRule(
+        fixedWindow({
+            mode: "LIVE",
+            window: "1m",
+            max: 5,
+        })
+    );
+
+export async function POST(request: Request) {
     try {
+
+        // Check Authentication
+        const session = await auth.api.getSession({
+            headers: await headers(),
+        });
+
+        // Check if the user is authenticated
+        if (!session?.user) {
+            return NextResponse.json({
+                error: "Unauthorized",
+            }, {
+                status: 401
+            });
+        }
+
+        // Protect the route with Arcjet
+        const decision = await aj.protect(request, {
+            fingerprint: session.user.id,
+        });
+
+        // Check if the request is denied by Arcjet
+        if (decision.isDenied()) {
+            return NextResponse.json({
+                error: "Too many requests",
+            }, {
+                status: 429
+
+            });
+        }
+
+        // Generate ImageKit authentication
         const { token, expire, signature } = getUploadAuthParams({
             privateKey: env.IMAGEKIT_PRIVATE_KEY,
             publicKey: env.NEXT_PUBLIC_IMAGEKIT_PUBLIC_KEY,
@@ -14,6 +64,8 @@ export async function GET() {
             expire,
             signature,
             publicKey: env.NEXT_PUBLIC_IMAGEKIT_PUBLIC_KEY,
+        }, {
+            status: 200
         });
     } catch (error) {
         console.error("ImageKit authentication error:", error);
@@ -21,7 +73,7 @@ export async function GET() {
         return NextResponse.json({
             error: "Failed to generate ImageKit authentication",
         }, {
-            status: 500,
+            status: 500
         });
     }
 }

--- a/lms-course-platform/src/components/file-uploader/Uploader.tsx
+++ b/lms-course-platform/src/components/file-uploader/Uploader.tsx
@@ -76,7 +76,10 @@ export default function Uploader({ value, onChange }: UploaderProps) {
              * Get ImageKit authentication parameters
              */
             const authResponse = await fetch("/api/imagekit/upload", {
-                method: "GET",
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
             });
 
             if (!authResponse.ok) {
@@ -373,7 +376,7 @@ export default function Uploader({ value, onChange }: UploaderProps) {
         );
     }
 
-    const { getRootProps,getInputProps,isDragActive } = useDropzone({
+    const { getRootProps, getInputProps, isDragActive } = useDropzone({
         onDrop,
         accept: {
             "image/*": [".jpeg", ".jpg", ".png", ".webp"],


### PR DESCRIPTION
Add authentication checks and Arcjet protection to the ImageKit upload and delete endpoints to prevent unauthorized and abusive usage.

- Require an authenticated session, returning 401 for unauthenticated requests on both upload and delete routes
- Apply Arcjet bot detection and a fixed-window rate limit (5 requests per minute), fingerprinted by user ID, returning 429 when denied
- Change the upload auth params endpoint from GET to POST and update the Uploader component accordingly