### PR TITLE
feat(admin): add admin guard, Arcjet protection, and user ban fields

### DIFF
--- a/lms-course-platform/prisma/schema.prisma
+++ b/lms-course-platform/prisma/schema.prisma
@@ -24,6 +24,11 @@ model User {
   accounts      Account[]
   courses       Course[]
 
+  role       String?
+  banned     Boolean?  @default(false)
+  banReason  String?
+  banExpires DateTime?
+
   @@unique([email])
   @@map("user")
 }
@@ -39,8 +44,11 @@ model Session {
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  impersonatedBy String?
+
   @@unique([token])
   @@map("session")
+  @@index([userId])
 }
 
 model Account {
@@ -60,8 +68,9 @@ model Account {
   createdAt             DateTime
   updatedAt             DateTime
 
-  @@unique([issuer, accountId])
+  @@unique([issuer, accountId], map: "account_issuer_accountId_uidx")
   @@map("account")
+  @@index([userId])
 }
 
 model Verification {
@@ -73,6 +82,7 @@ model Verification {
   updatedAt  DateTime?
 
   @@map("verification")
+  @@index([identifier])
 }
 
 model Course {

--- a/lms-course-platform/src/app/admin/courses/action.ts
+++ b/lms-course-platform/src/app/admin/courses/action.ts
@@ -1,54 +1,89 @@
-'use server';
+"use server";
 
-import { auth } from "@/lib/auth";
+import { requireAdmin } from "@/app/data/admin/require-admin";
+import arcjet, { detectBot, fixedWindow } from "@/lib/arcjet";
 import { prisma } from "@/lib/db";
 import { courseSchema, CourseSchema } from "@/lib/zodSchema";
-import { headers } from "next/headers";
+import { request } from "@arcjet/next";
+
+const aj = arcjet
+    .withRule(
+        detectBot({
+            mode: "LIVE",
+            allow: [],
+        })
+    )
+    .withRule(
+        fixedWindow({
+            mode: "LIVE",
+            window: "1m",
+            max: 5,
+        })
+    );
 
 export async function createCourse(values: CourseSchema) {
-    try {
+    const session = await requireAdmin();
 
-        const session = await auth.api.getSession({
-            headers: await headers(),
+    try {
+        // Get current request for Arcjet
+        const req = await request();
+
+        // Protect Server Action with Arcjet
+        const decision = await aj.protect(req, {
+            fingerprint: session.user.id,
         });
 
-        if (!session) {
+        if (decision.isDenied()) {
+            if (decision.reason.isRateLimit()) {
+                return {
+                    success: false,
+                    status: "error",
+                    message: "Too many requests. Please try again later.",
+                };
+            }
+
             return {
                 success: false,
-                status: 'error',
-                message: 'User not authenticated',
+                status: "error",
+                message: "Request denied. Please try again later.",
             };
         }
 
+        // Validate course data
         const validation = courseSchema.safeParse(values);
 
         if (!validation.success) {
             return {
                 success: false,
-                status: 'error',
-                message: 'Invalid data Format',
+                status: "error",
+                message: "Invalid data format.",
             };
         }
 
+        // Create course
         await prisma.course.create({
             data: {
                 ...validation.data,
-                userId: session?.user.id,
+                userId: session.user.id,
             },
         });
 
         return {
             success: true,
-            status: 'success',
-            message: 'Course created successfully',
+            status: "success",
+            message: "Course created successfully.",
         };
+        
     } catch (error) {
-        console.error('Error creating course:', error);
+        console.error(
+            "Error creating course:",
+            error
+        );
 
         return {
             success: false,
-            status: 'error',
-            message: 'Failed to create course',
+            status: "error",
+            message: "Failed to create course.",
         };
     }
-};
+}

--- a/lms-course-platform/src/app/admin/layout.tsx
+++ b/lms-course-platform/src/app/admin/layout.tsx
@@ -1,8 +1,10 @@
 import { AppSidebar } from "@/components/sidebar-ui/app-sidebar"
 import { SiteHeader } from "@/components/sidebar-ui/site-header"
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar"
+import { requireAdmin } from "@/app/data/admin/require-admin"
 
-export default function AdminLayout({children}: {children: React.ReactNode}) {
+export default async function AdminLayout({children}: {children: React.ReactNode}) {
+    await requireAdmin();
     return (
         <SidebarProvider
             style={

--- a/lms-course-platform/src/app/api/imagekit/delete/route.ts
+++ b/lms-course-platform/src/app/api/imagekit/delete/route.ts
@@ -1,8 +1,7 @@
 import { env } from "@/lib/env";
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
 import arcjet, { detectBot, fixedWindow } from "@/lib/arcjet";
-import { auth } from "@/lib/auth";
+import { getAdminSession } from "@/app/data/admin/require-admin";
 
 // Route-specific Arcjet rules
 const aj = arcjet
@@ -21,21 +20,17 @@ const aj = arcjet
     );
 
 export async function DELETE(request: Request) {
-    try {
+    const session = await getAdminSession();
 
-        // Check Authentication
-        const session = await auth.api.getSession({
-            headers: await headers(),
+    if (!session) {
+        return NextResponse.json({
+            error: "Forbidden: Admin access required",
+        }, {
+            status: 403,
         });
-
-        // Check if the user is authenticated
-        if (!session?.user) {
-            return NextResponse.json({
-                error: "Unauthorized",
-            }, {
-                status: 401
-            });
-        }
+    }
+    
+    try {
 
         // Protect the route with Arcjet
         const decision = await aj.protect(request, {

--- a/lms-course-platform/src/app/api/imagekit/upload/route.ts
+++ b/lms-course-platform/src/app/api/imagekit/upload/route.ts
@@ -1,9 +1,8 @@
 import { getUploadAuthParams } from "@imagekit/next/server";
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
 import { env } from "@/lib/env";
 import arcjet, { detectBot, fixedWindow } from "@/lib/arcjet";
-import { auth } from "@/lib/auth";
+import { getAdminSession } from "@/app/data/admin/require-admin";
 
 // Route-specific Arcjet rules
 const aj = arcjet
@@ -22,22 +21,17 @@ const aj = arcjet
     );
 
 export async function POST(request: Request) {
-    try {
+    const session = await getAdminSession();
 
-        // Check Authentication
-        const session = await auth.api.getSession({
-            headers: await headers(),
+    if (!session) {
+        return NextResponse.json({
+            error: "Forbidden: Admin access required",
+        }, {
+            status: 403,
         });
+    }
 
-        // Check if the user is authenticated
-        if (!session?.user) {
-            return NextResponse.json({
-                error: "Unauthorized",
-            }, {
-                status: 401
-            });
-        }
-
+    try {
         // Protect the route with Arcjet
         const decision = await aj.protect(request, {
             fingerprint: session.user.id,
@@ -67,6 +61,7 @@ export async function POST(request: Request) {
         }, {
             status: 200
         });
+        
     } catch (error) {
         console.error("ImageKit authentication error:", error);
 

--- a/lms-course-platform/src/app/data/admin/require-admin.ts
+++ b/lms-course-platform/src/app/data/admin/require-admin.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+export async function getAdminSession() {
+    const session = await auth.api.getSession({
+        headers: await headers(),
+    });
+
+    if (!session || session.user.role !== "admin") {
+        return null;
+    }
+
+    return session;
+}
+
+export async function requireAdmin() {
+    const session = await getAdminSession();
+
+    if (!session) {
+        const currentSession = await auth.api.getSession({
+            headers: await headers(),
+        });
+
+        if (!currentSession) {
+            redirect("/login");
+        }
+
+        redirect("/not-admin");
+    }
+
+    return session;
+}

--- a/lms-course-platform/src/app/not-admin/page.tsx
+++ b/lms-course-platform/src/app/not-admin/page.tsx
@@ -1,0 +1,20 @@
+import { buttonVariants } from '@/components/ui/button';
+import { ShieldAlert } from 'lucide-react';
+import Link from 'next/link';
+
+export default function NotAdminPage() {
+    return (
+        <div className="flex flex-col items-center justify-center min-h-svh gap-6">
+            <ShieldAlert className="h-16 w-16 text-destructive" />
+            <div className="text-center space-y-2">
+                <h1 className="text-2xl font-bold">Access Denied</h1>
+                <p className="text-muted-foreground">
+                    You do not have administrator privileges to access this page.
+                </p>
+            </div>
+            <Link href="/" className={buttonVariants({ variant: "outline" })}>
+                Back to Home
+            </Link>
+        </div>
+    );
+}

--- a/lms-course-platform/src/components/file-uploader/Uploader.tsx
+++ b/lms-course-platform/src/components/file-uploader/Uploader.tsx
@@ -77,13 +77,11 @@ export default function Uploader({ value, onChange }: UploaderProps) {
              */
             const authResponse = await fetch("/api/imagekit/upload", {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                },
             });
 
             if (!authResponse.ok) {
-                throw new Error("Failed to authenticate with ImageKit");
+                const errorData = await authResponse.json().catch(() => null);
+                throw new Error(errorData?.error || "Failed to authenticate with ImageKit");
             }
 
             const { token, expire, signature, publicKey } = await authResponse.json();

--- a/lms-course-platform/src/components/ui/themeToggle.tsx
+++ b/lms-course-platform/src/components/ui/themeToggle.tsx
@@ -10,12 +10,14 @@ export function ThemeToggle() {
 
     return (
         <DropdownMenu>
-            <DropdownMenuTrigger>
-                <Button variant="outline" size="icon">
-                    <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-                    <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-                    <span className="sr-only">Toggle theme</span>
-                </Button>
+            <DropdownMenuTrigger
+                render={
+                    <Button variant="outline" size="icon" />
+                }
+            >
+                <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+                <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+                <span className="sr-only">Toggle theme</span>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={() => setTheme("light")}>

--- a/lms-course-platform/src/lib/auth-client.ts
+++ b/lms-course-platform/src/lib/auth-client.ts
@@ -1,8 +1,9 @@
 import { createAuthClient } from "better-auth/react"
-import { emailOTPClient } from 'better-auth/client/plugins';
+import { adminClient, emailOTPClient } from 'better-auth/client/plugins';
 
 export const authClient = createAuthClient({
     plugins: [
-        emailOTPClient()
+        emailOTPClient(),
+        adminClient(),
     ]
 })

--- a/lms-course-platform/src/lib/auth.ts
+++ b/lms-course-platform/src/lib/auth.ts
@@ -1,10 +1,8 @@
-import 'server-only';
-
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { prisma } from "./db";
 import { env } from "./env";
-import { emailOTP } from 'better-auth/plugins'
+import { admin, emailOTP } from 'better-auth/plugins'
 import { resend } from "./resend";
 
 export const auth = betterAuth({
@@ -30,5 +28,6 @@ export const auth = betterAuth({
 
             },
         }),
+        admin(),
     ]
 });

--- a/lms-course-platform/src/lib/db.ts
+++ b/lms-course-platform/src/lib/db.ts
@@ -1,5 +1,3 @@
-import "server-only";
-
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@/generated/prisma/client";
 

--- a/lms-course-platform/src/lib/resend.ts
+++ b/lms-course-platform/src/lib/resend.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import { Resend } from 'resend';
 import { env } from './env';
 


### PR DESCRIPTION
- Add role, banned, banReason, and banExpires fields to User model and impersonatedBy to Session to support admin authorization and user impersonation features
- Add indexes on session.userId, account.userId, and verification.identifier to improve query performance
- Protect createCourse server action with Arcjet bot detection and fixed-window rate limiting (5 requests per minute per user)
- Replace manual session checks with requireAdmin() guard in admin routes and server actions for consistent authorization