### PR TITLE
fix(auth): harden session user access and IP fallback in auth checks

### DIFF
--- a/lms-course-platform/src/app/api/auth/[...all]/route.ts
+++ b/lms-course-platform/src/app/api/auth/[...all]/route.ts
@@ -32,7 +32,8 @@ async function protect(req: NextRequest): Promise<ArcjetDecision> {
         headers: req.headers,
     });
 
-    const userId = session?.user.id ?? ip(req) ?? "127.0.0.1";
+    const clientIp = ip(req);
+    const userId = session?.user?.id || (clientIp && clientIp.trim() !== "" ? clientIp : "127.0.0.1");
 
     if (req.nextUrl.pathname.startsWith("/api/auth/sign-up")) {
         const body = await req.clone().json();

--- a/lms-course-platform/src/app/data/admin/require-admin.ts
+++ b/lms-course-platform/src/app/data/admin/require-admin.ts
@@ -9,7 +9,7 @@ export async function getAdminSession() {
         headers: await headers(),
     });
 
-    if (!session || session.user.role !== "admin") {
+    if (!session || !session.user || session.user.role?.toLowerCase() !== "admin") {
         return null;
     }
 


### PR DESCRIPTION
- Add optional chaining for session.user and session.user.role to prevent runtime errors when user data is missing
- Treat empty client IP strings as absent and fall back to 127.0.0.1 as the rate-limit identifier instead of only checking nullish values
- Make the admin role comparison case-insensitive using toLowerCase()